### PR TITLE
manifest error

### DIFF
--- a/chrome/src/manifest.json
+++ b/chrome/src/manifest.json
@@ -9,7 +9,6 @@
 		"https://*/*",
 		"*://*/*",
 		"chrome://favicon/",
-		"management",
 		"history",
 		"cookies",
 		"tabs"


### PR DESCRIPTION
I get the following error when packing Fidelio:

> Invalid value for 'permissions[4]'.

This solves it under Chromium v6.0.472.62 (0) Linux.
