### PR TITLE
Fixing an error I found in URL handling

### DIFF
--- a/chrome/src/content.js
+++ b/chrome/src/content.js
@@ -42,7 +42,7 @@
 				return false;
 			
 			if(document.location.protocol != 'https:' && this.siteMatch(document.domain)) {
-				document.location = 'https://' + document.location.hostname + document.location.pathname + document.location.hash;
+				document.location = 'https://' + document.location.hostname + document.location.pathname + document.location.search + document.location.hash;
 			}	
 		},
 		


### PR DESCRIPTION
When a non-HTTPS URL has a query string, Fidelio does not pass it along when constructing the HTTPS URL. This commit fixes this.
